### PR TITLE
Give nested regexes higher priority on decorations

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -457,6 +457,12 @@ class Parser {
             regexRegExp = new RegExp(sRegex, (regex.regexFlag) ? regex.regexFlag : configuration.defaultRegexFlag);
             regexRegExp.test();
             let decorationList = [];
+            let regexList = [];
+            if (regex.regexes && regex.regexes.length > 0) {
+                for (let regexes of regex.regexes) {
+                    regexList.push(loadRegexes(configuration, regexes));
+                }
+            }
             if (regex.decorations && regex.decorations.length > 0) {
                 for (let decoration of regex.decorations) {
                     let index = (decoration.index) ? decoration.index : 0;
@@ -470,12 +476,6 @@ class Parser {
                         ranges: []
                     });
                     this.decorations.push(vscode.window.createTextEditorDecorationType(decoration));
-                }
-            }
-            let regexList = [];
-            if (regex.regexes && regex.regexes.length > 0) {
-                for (let regexes of regex.regexes) {
-                    regexList.push(loadRegexes(configuration, regexes));
                 }
             }
             return {


### PR DESCRIPTION
With the current implementation, when defining nested regexes (using an already captured group) and attempting to decorate the narrower capture, it is not possible to actually overlay those decorations on top of the parent regex, if they happen to affect the same decoration (e.g. setting whole line text color to white and specific words from the same capture to red).
This change just flips the order of how decorations are requested for nested regexes, so that they are taken first, the order of the same-level regexes is handled the same from my testing.


**Example for comparison:**
All numbers will be generally colored yellow, 4 and 7 will be red.

**Plain text:**
`testing 123456789`

**Settings:**
```json
"highlight.regex.regexes": [
  {
    "languageIds": ["plaintext"],
    "regexes": [
      {
        "regex": "\\d+",
        "decorations": [{ "color": "yellow" }],
        "regexes": [
          {
            "regex": "(4|7)",
            "decorations": [{ "color": "red" }]
          }
        ]
      }
    ]
  }
]
```