### PR TITLE
Added named backreference resolving

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -410,6 +410,26 @@ class Parser {
 
 							start = i + 1;
 						}
+						// is named backreference
+						// NOTE: In unicode-unaware mode, this CAN (but shouldn't) cause issues (`\k` resolves to literal `k` unless a group matches)
+						//       https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_backreference#description
+						if ('\\' === text[i] && 'k' === text[i + 1] && '<' === text[i + 2]) {
+							i += 3; // skip `\k<`
+
+							let groupName = "";
+							for (let j = i; j < text.length; j++) {
+								i++;
+								if (text[j] === '>') {
+									break;
+								}
+								groupName += text[j];
+							}
+
+							let index = matchNamedToReal[groupName];
+							newStrRegex += `\\${index.toString()}`;
+
+							start = i + 1;
+						}
 					}
 					if (start > 0 && text.length > (end + 1) && text.length - start > 0) {
 						addSimpleGroup(text.substr(start, text.length - start));


### PR DESCRIPTION
Noticed that due to the group remapping, named references are lost, so named backreferences `\k<name>` do not get replaced/matched. This PR is to add that capability.
If need be, more info on named backreferences can be found [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_backreference)

![image](https://github.com/user-attachments/assets/9e4e321c-ddda-4581-b57f-36e94a28ef12)

Test settings:
```
"highlight.regex.regexes": [
  {
    "languageIds": ["plaintext"],
    "name": "Quote test",
    "regexes": [
      {
        "regex": "(?<quote>[\"'])(?<contents>.*)\\k<quote>",
        "regexFlag": "g",
        "decorations": [
          {
            "backgroundColor": "red",
            "color": "black",
            "index": "contents"
          }
        ]
      }
    ]
  }
]
```

Test text:
```
Test no quotes
Test "no" quotes
Also works for 'single quotes'
"But without a pair it's okay"
```

Also as for error handling in case an invalid named group is backreferenced, it seems to be handled by the initial check:
![image](https://github.com/user-attachments/assets/be19377a-7fd2-4cbb-912b-e47260b42d1a)
